### PR TITLE
Add get_state() method to KazooServiceRegistry.

### DIFF
--- a/nd_service_registry/__init__.py
+++ b/nd_service_registry/__init__.py
@@ -180,7 +180,7 @@ class nd_service_registry(object):
         time the connection state changes.
 
         args:
-            callback: Method to execute if the connection state changes.
+            callback: Function to execute if the connection state changes.
 
         returns:
             True/False
@@ -560,8 +560,8 @@ class KazooServiceRegistry(nd_service_registry):
 
         # Store our connection state, and a list of methods to notify
         # if that state changes at all.
-        self._state = False
-        self._state_callbacks = []
+        self._conn_state = False
+        self._conn_state_callbacks = []
 
         # Store all of our Registration objects here
         self._registrations = {}
@@ -830,17 +830,17 @@ class KazooServiceRegistry(nd_service_registry):
             # In this state, just mark that we can't handle any 'writes' right
             # now but that we might come back to life soon.
             log.warning('%s: %s' % (message, state))
-            self._state = False
+            self._conn_state = False
         elif state == KazooState.LOST:
             # If we enter the LOST state, we've started a whole new session
             # with the Zookeeper server. Watches are re-established auto-
             # magically. Registered paths are re-established by their own
             # Registration control objects.
             log.warning('%s: %s' % (message, state))
-            self._state = False
+            self._conn_state = False
         else:
             log.info('%s: %s' % (message, state))
-            self._state = True
+            self._conn_state = True
             # We've re-connected, so re-configure our auth digest settings
             self._setup_auth()
 
@@ -856,38 +856,43 @@ class KazooServiceRegistry(nd_service_registry):
         # Execute any of our state-listener callbacks now that we've finished
         # updating the internal state of our connection.
         def execute_state_callbacks(state):
-            log.debug('Configured connection state callbacks: %s' %
-                      self._state_callbacks)
+            """Sequentially executes the callback functions.
 
-            for callback in self._state_callbacks:
+            args:
+                state: Boolean of our connection state
+            """
+            log.debug('Configured connection state callbacks: %s' %
+                      self._conn_state_callbacks)
+
+            for callback in self._conn_state_callbacks:
                 log.debug('Calling [%s] with new connection state: %s' %
                           (callback, state))
                 callback(state)
 
-        self._zk.handler.spawn(execute_state_callbacks(self._state))
+        self._zk.handler.spawn(execute_state_callbacks(self._conn_state))
 
     def _get_state(self, callback=None):
         """Returns the current connection state to Zookeeper.
 
-        Optionally, if a callback method is supplied we will add it to the
-        callback list for the _state_listener() method. This will trigger the
+        Optionally, if a callback function is supplied we will add it to the
+        callback list for the _state_listener() function. This will trigger the
         callback immediately as well.
 
         args:
-            callback: A reference to a method to call when the state changes.
+            callback: A reference to a function to call when the state changes.
 
         returns:
             Boolean of the connection state.
         """
-        if callback and callback in self._state_callbacks:
+        if callback and callback in self._conn_state_callbacks:
             log.debug('[%s] already in state listener callbacks.' % callback)
-            return self._state
+            return self._conn_state
 
         if callback:
-            self._state_callbacks.append(callback)
-            callback(self._state)
+            self._conn_state_callbacks.append(callback)
+            callback(self._conn_state)
 
-        return self._state
+        return self._conn_state
 
     def add_callback(self, path, callback):
         """Adds a callback in the event of a path change.

--- a/nd_service_registry/sr_integration.py
+++ b/nd_service_registry/sr_integration.py
@@ -1,3 +1,5 @@
+import mock
+
 from kazoo.testing import KazooTestHarness
 from nd_service_registry import KazooServiceRegistry
 
@@ -15,6 +17,7 @@ class KazooServiceRegistryIntegrationTests(KazooTestHarness):
 
     def tearDown(self):
         self.teardown_zookeeper()
+        self.ndsr._initialized = False
 
     def test_get_state(self):
         self.ndsr.start()
@@ -22,3 +25,15 @@ class KazooServiceRegistryIntegrationTests(KazooTestHarness):
 
         self.ndsr.stop()
         self.assertFalse(self.ndsr.get_state())
+
+    def test_get_state_with_callback(self):
+        # With a callback, the callback should get executed
+        callback_checker = mock.MagicMock()
+        callback_checker.test.return_value = True
+
+        self.ndsr.start()
+        self.ndsr.get_state(callback_checker.test)
+        self.ndsr.stop()
+
+        self.assertTrue(mock.call(True) in callback_checker.test.mock_calls)
+        self.assertTrue(mock.call(False) in callback_checker.test.mock_calls)

--- a/nd_service_registry/sr_tests.py
+++ b/nd_service_registry/sr_tests.py
@@ -7,6 +7,12 @@ import nd_service_registry
 
 
 class KazooServiceRegistryTests(unittest.TestCase):
+    """Behavioral tests for the KazooServiceRegistry.
+
+    These tests verify the overall behavior of the entire class as used
+    by potential clients.
+    """
+
     # A flag for filtering nose tests
     unit = True
 
@@ -20,10 +26,10 @@ class KazooServiceRegistryTests(unittest.TestCase):
         self.ndsr._initialized = False
 
     def test_get_state(self):
-        # Simple checks should return the value of self.ndsr._state
-        self.ndsr._state = True
+        # Simple checks should return the value of self.ndsr._conn_state
+        self.ndsr._conn_state = True
         self.assertTrue(self.ndsr.get_state())
-        self.ndsr._state = False
+        self.ndsr._conn_state = False
         self.assertFalse(self.ndsr.get_state())
 
     def test_get_state_with_callback(self):
@@ -32,11 +38,12 @@ class KazooServiceRegistryTests(unittest.TestCase):
         callback_checker.test.return_value = True
 
         # Mock the state to be True
-        self.ndsr._state = True
+        self.ndsr._conn_state = True
 
         # Ensure that we return True, and that the callback is in the callbacks
         self.assertTrue(self.ndsr.get_state(callback_checker.test))
-        self.assertTrue(callback_checker.test in self.ndsr._state_callbacks)
+        self.assertTrue(
+            callback_checker.test in self.ndsr._conn_state_callbacks)
         callback_checker.test.assert_called_once_with(True)
 
     def test_state_callback_with_updated_state(self):
@@ -45,12 +52,13 @@ class KazooServiceRegistryTests(unittest.TestCase):
         callback_checker.test.return_value = True
 
         # Mock the state to be True
-        self.ndsr._state = True
+        self.ndsr._conn_state = True
 
         # Add our callback checker mock above and validate that the callback
         # was executed once with True.
         self.ndsr.get_state(callback_checker.test)
-        self.assertTrue(callback_checker.test in self.ndsr._state_callbacks)
+        self.assertTrue(
+            callback_checker.test in self.ndsr._conn_state_callbacks)
         callback_checker.test.assert_called_with(True)
 
         # Now fake a state change to LOST


### PR DESCRIPTION
The get_state() method returns the current known
conection state of the KazooServiceRegistry object to
Zookeeper. This state is managed by the _state_listener()
method and is updated any time a connection state change
is detected.

get_state() also accepts an optional callback argument
that will add a callback to the state listener and update
that callback any time the connection state changes.
