### PR TITLE
This is potentially dangerous behavior in large installations where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 1.0.0-alpha
+ * #39: Completely remove get_data() calls from the children of watched paths.
+
 ## Version 0.3.2
  * Bugfix: Ensure Kazoo is between 1.3 and 2.0.
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,7 @@ track of which servers are offering specific services.
     >>> nd.set_node('/production/web/server2:22',
                     data={'type': 'apache'})
     >>> nd.get('/production/ssh')
-    {'children': {u'server1:22': {u'created': u'2012-12-15 01:15:09',
-                                  u'pid': 11137},
-                  u'server2:22': {u'created': u'2012-12-15 01:15:14',
-                                  u'pid': 11137},
-                  u'server3:22': {u'created': u'2012-12-15 01:15:18',
-                                  u'pid': 11137}},
+    {'children': [u'server1:22', u'server2:22', u'server3:22' ],
      'data': None,
      'path': '/production/ssh',
      'stat': ZnodeStat(czxid=27, mzxid=27, ctime=1355533229452,
@@ -100,7 +95,7 @@ When you want to store arbitrary (but simple!) data objects in, its simple!
     >>> sr.set_data('/config/my_app', data={'state': 'enabled'})
     True
     >>> sr.get('/config/my_app')
-    {'children': {},
+    {'children': []
      'data': {u'created': u'2014-06-03 13:37:53',
               u'pid': 2546,
               u'state': u'enabled'},

--- a/nd_service_registry/__init__.py
+++ b/nd_service_registry/__init__.py
@@ -48,12 +48,7 @@ Example usage to provide the above service list:
 Example of getting a static list of nodes from /production/ssh:
 
     >>> nd.get('/production/ssh')
-    {'children': {u'server1:22': {u'created': u'2012-12-15 01:15:09',
-                                  u'pid': 11137},
-                  u'server2:22': {u'created': u'2012-12-15 01:15:14',
-                                  u'pid': 11137},
-                  u'server3:22': {u'created': u'2012-12-15 01:15:18',
-                                  u'pid': 11137}},
+    {'children': [u'server1:22', u'server2:22', u'server3:22' ],
      'data': None,
      'path': '/production/ssh',
      'stat': ZnodeStat(czxid=27, mzxid=27, ctime=1355533229452,
@@ -76,14 +71,7 @@ to the get() function.
     ...     pprint.pprint(nodes['children'])
     ...
     >>> nd.get('/production/ssh', callback=list)
-    {
-      u'server1:22': {u'pid': 12345,
-                      u'created': u'2012-12-12 15:26:24'}
-      u'server2:22': {u'pid': 12345,
-                      u'created': u'2012-12-12 15:26:24'}
-      u'server3:22': {u'pid': 12345,
-                      u'created': u'2012-12-12 15:26:24'}
-    }
+    [u'server1:22', u'server2:22', u'server3:22']
 
 Example of doing some work with a lock in place:
 

--- a/nd_service_registry/registration_integration.py
+++ b/nd_service_registry/registration_integration.py
@@ -66,7 +66,7 @@ class RegistrationBaseTests(KazooTestHarness):
         # registered the path.
         self.assertEquals(None, reg1.data())
         self.assertEquals({'path': path, 'stat': None,
-                           'data': None, 'children': {}}, reg1.get())
+                           'data': None, 'children': []}, reg1.get())
         self.assertFalse(reg1.state())
         self.assertEquals(None, self.zk.exists(path))
 
@@ -118,7 +118,7 @@ class RegistrationBaseTests(KazooTestHarness):
         waituntil(reg1.data, current_data, 5)
         self.assertFalse(reg1.state())
         self.assertEquals({'path': path, 'stat': None,
-                           'data': None, 'children': {}}, reg1.get())
+                           'data': None, 'children': []}, reg1.get())
         self.assertEquals(None, self.zk.exists(path))
 
     def test_stop(self):

--- a/nd_service_registry/version.py
+++ b/nd_service_registry/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.2'  # http://semver.org/
+__version__ = '1.0.0-alpha'  # http://semver.org/

--- a/nd_service_registry/watcher_integration.py
+++ b/nd_service_registry/watcher_integration.py
@@ -48,7 +48,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # We expect there to be valid data...
         self.assertEquals(None, watch.get()['data'])
         self.assertNotEquals(None, watch.get()['stat'])
-        self.assertEquals({}, watch.get()['children'])
+        self.assertEquals([], watch.get()['children'])
 
         # Now register a child node, and expect the data to change
         child_path = '%s/my_child_test' % path
@@ -59,7 +59,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         def get_children():
             print "got: %s" % watch.get()['children']
             return watch.get()['children']
-        waituntil(get_children, {}, timeout=5)
+        waituntil(get_children, [], timeout=5)
 
         # Now expect the watch to be kicked off
         self.assertTrue('my_child_test' in watch.get()['children'])
@@ -72,7 +72,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # to be None because the node doesn't exist.
         self.assertEquals(None, watch.get()['data'])
         self.assertEquals(None, watch.get()['stat'])
-        self.assertEquals({}, watch.get()['children'])
+        self.assertEquals([], watch.get()['children'])
 
         # Now, lets go and set the data path with something. We expect the
         # watcher now to actually register the change. Use the waituntil()
@@ -87,7 +87,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         self.assertEquals(
             {'string_value': "{'foo': 'bar'}"}, watch.get()['data'])
         self.assertNotEquals(None, watch.get()['stat'])
-        self.assertEquals({}, watch.get()['children'])
+        self.assertEquals([], watch.get()['children'])
 
     def test_watch_on_nonexistent_path_with_children_change(self):
         path = '%s/nonexistent-path-%s' % (self.sandbox, uuid.uuid4().hex)
@@ -97,7 +97,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # to be None because the node doesn't exist.
         self.assertEquals(None, watch.get()['data'])
         self.assertEquals(None, watch.get()['stat'])
-        self.assertEquals({}, watch.get()['children'])
+        self.assertEquals([], watch.get()['children'])
 
         # Now register a child node under the path, and expect the
         # data to change
@@ -107,7 +107,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # Wait until the children list changes
         def get_children():
             return watch.get()['children']
-        waituntil(get_children, {}, timeout=5)
+        waituntil(get_children, [], timeout=5)
 
         # Now verify that the data has been updated in our Watcher
         self.assertTrue('my_child_test' in watch.get()['children'])
@@ -126,7 +126,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # to be None because the node doesn't exist.
         self.assertEquals(None, watch.get()['data'])
         self.assertEquals(None, watch.get()['stat'])
-        self.assertEquals({}, watch.get()['children'])
+        self.assertEquals([], watch.get()['children'])
 
         # Now register a child node under the path, and expect the
         # data to change
@@ -136,7 +136,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # Wait until the children list changes
         def get_children():
             return watch.get()['children']
-        waituntil(get_children, {}, timeout=5)
+        waituntil(get_children, [], timeout=5)
 
         # Now verify that the data has been updated in our Watcher
         self.assertTrue('my_child_test' in watch.get()['children'])
@@ -173,7 +173,7 @@ class WatcherIntegrationTests(KazooTestHarness):
         # point, our Watcher object should cleanly update itself indicating
         # that the path no longer exists.
         expected_get_results = {
-            'path': path, 'stat': None, 'data': None, 'children': {}}
+            'path': path, 'stat': None, 'data': None, 'children': []}
         waituntil(watch.get, expected_get_results, 5, mode=2)
         self.assertEquals(expected_get_results, watch.get())
 

--- a/nd_service_registry/watcher_tests.py
+++ b/nd_service_registry/watcher_tests.py
@@ -86,34 +86,6 @@ class WatcherTests(unittest.TestCase):
         self.assertTrue(self.watch._current_children_watch is None)
 
     def test_update_children(self):
-        # Mock out the zk.retry() function to return some fake data
-        # because the _update_children() function optionally calls out
-        # to it for each of the children that are passed into the function.
-        #
-        # (NOTE: This behavior is being deprecated)
-        self.zk.retry.return_value = ('data', 'stat')
-
-        # Here is our list of fake children, and what we expect will be stored
-        # in the object once the function has completed. Notice it includes the
-        # 'data' return value above.
-        fake_children = ['child2', 'child1']
-        expected_children_dict = {
-            'child1': {'string_value': 'data'},
-            'child2': {'string_value': 'data'}
-        }
-
-        # Execute the _update_children() function with our fake_children above
-        self.watch._update_children(fake_children)
-
-        # Ensure that the hash returned has a sorted list of children
-        self.assertEquals((self.watch._children.keys()), sorted(fake_children))
-        self.assertEquals(self.watch._children, expected_children_dict)
-
-    def test_update_children_with_getdata_disabled(self):
-        # Explicitly disable the retrieval of 'data' information from each
-        # of the children when the _update_children() function is executed
-        self.watch._get_children_data = False
-
         # In this test, self.zk.retry() should never be called so we don't
         # hae to mock it out. Just supply a list of children, and this list
         # should be stored and then the callbacks should be executed.


### PR DESCRIPTION
thousands of clients could all start slamming the Zookeeper hosts with
'get' calls.

The watches themselves should push data to the clients, and the clients
should just accept it -- without making further calls. This change
deprecates the old behavior.

(issue #39)
