### PR TITLE
Support kazoo up to version 2.5.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 *.egg-info
 *.swp
 .coverage
+.mypy_cache
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ env:
   - KAZOO_VERSION=2.0
   - KAZOO_VERSION=2.2
   - KAZOO_VERSION=2.5.0
+jobs:
+  exclude:
+    - python: "3.7"
+      env: KAZOO_VERSION=1.3
+    - python: "3.7"
+      env: KAZOO_VERSION=2.0
+    - python: "3.7"
+      env: KAZOO_VERSION=2.2
 install:
   - pip install kazoo==$KAZOO_VERSION
   - make zookeeper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
+  - "3.6"
+  - "3.7"
 env:
   - KAZOO_VERSION=1.3
   - KAZOO_VERSION=2.0
   - KAZOO_VERSION=2.2
+  - KAZOO_VERSION=2.5.0
 install:
   - pip install kazoo==$KAZOO_VERSION
   - make zookeeper

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - KAZOO_VERSION=2.5.0
 jobs:
   exclude:
+    - python: "3.6"
+      env: KAZOO_VERSION=2.0
     - python: "3.7"
       env: KAZOO_VERSION=1.3
     - python: "3.7"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DIRS = bin build include lib lib64 man share
 ZOOKEEPER = $(BIN)/zookeeper
 ZOOKEEPER_VERSION ?= 3.4.8
 ZOOKEEPER_PATH ?= $(ZOOKEEPER)
-ZOOKEEPER_URL = http://apache.osuosl.org/zookeeper/zookeeper-$(ZOOKEEPER_VERSION)/zookeeper-$(ZOOKEEPER_VERSION).tar.gz
+ZOOKEEPER_URL = https://archive.apache.org/dist/zookeeper/zookeeper-$(ZOOKEEPER_VERSION)/zookeeper-$(ZOOKEEPER_VERSION).tar.gz
 
 .PHONY: all build clean test zookeeper clean-zookeeper
 

--- a/nd_service_registry/registration.py
+++ b/nd_service_registry/registration.py
@@ -210,11 +210,11 @@ class RegistrationBase(object):
             # The underlying path does not exist. Raise this exception, and
             # _update_state() handle it.
             raise
-        except kazoo.exceptions.NodeExistsError as e:
+        except kazoo.exceptions.NodeExistsError:
             # Node exists ... possible this callback got called multiple
             # times
             pass
-        except kazoo.exceptions.NoAuthError as e:
+        except kazoo.exceptions.NoAuthError:
             log.error('[%s] No authorization to create node.' % self._path)
         except Exception as e:
             log.error(RegistrationBase.GENERAL_EXC_MSG % (self._path, e))
@@ -256,7 +256,7 @@ class RegistrationBase(object):
         log.debug('[%s] Attempting de-registration...' % self._path)
         try:
             self._zk.retry(self._zk.delete, self._path)
-        except kazoo.exceptions.NoAuthError as e:
+        except kazoo.exceptions.NoAuthError:
             # The node exists, but we don't even have authorization to read
             # it. We certainly will not have access then to change it below
             # so return false. We'll retry again very soon.
@@ -270,7 +270,7 @@ class RegistrationBase(object):
             self._zk.retry(self._zk.set, self._path, value=self._encoded_data)
             log.debug('[%s] Updated with data: %s' %
                       (self._path, self._encoded_data))
-        except kazoo.exceptions.NoAuthError as e:
+        except kazoo.exceptions.NoAuthError:
             log.error('[%s] No authorization to set node.' % self._path)
         except Exception as e:
             log.error(RegistrationBase.GENERAL_EXC_MSG % (self._path, e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future
-kazoo>=1.3,<2.3
+kazoo>=1.3,<=2.5.0
 pyyaml
 setuptools
 six


### PR DESCRIPTION
Support newer versions of kazoo that seems to work with python 3.7.
This passes the unit tests and integration tests.

I had trouble getting 2.6.0+ working and it looks like it's b/c it
requires a new version of zookeeper for testing. Simply upgrading that
version wasn't enough, so this requires more investigation.